### PR TITLE
fix: bug on initial render

### DIFF
--- a/germ-finder-general/index.html
+++ b/germ-finder-general/index.html
@@ -152,13 +152,11 @@
         )
     }
 
-    m.mount(root, App)
-
     fetch("conditions.json").then(
         response => response.json()
     ).then(data => {
         App.conditions = data;
-        App.render()
+        m.mount(root, App)
     })
 
 	    </script>


### PR DESCRIPTION
Avoid a console error when trying to perform the initial render after loading the species conditions data by mounting the app only after the data is fully loaded